### PR TITLE
Add in-place and layouts

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -198,6 +198,12 @@
     "description": "Ignore any files that match a pattern."
   },
   {
+    "name": "In-place",
+    "icon": "files",
+    "repository": "https://github.com/superwolff/metalsmith-in-place",
+    "description": "In-place templating, render templates in your source files."
+  },
+  {
     "name": "Include",
     "icon": "downloadfolder",
     "repository": "https://github.com/treygriffith/metalsmith-include",
@@ -220,6 +226,12 @@
     "icon": "files",
     "repository": "https://github.com/kwizzn/metalsmith-kss",
     "description": "Add KSS styleguide information."
+  },
+  {
+    "name": "Layouts",
+    "icon": "files",
+    "repository": "https://github.com/superwolff/metalsmith-layouts",
+    "description": "Apply layouts to your source files."
   },
   {
     "name": "LESS",


### PR DESCRIPTION
Just proposing these plugins (see [this issue](https://github.com/segmentio/metalsmith-templates/issues/35)), since @ianstormtaylor thought they'd be useful.

I can understand that some might say these aren't different enough from `metalsmith-templates`, so I'll let you decide whether to include them or not. I'd be willing to transfer ownership of the plugins to segmentio as well, should you want more control over the plugins.