### PR TITLE
Adding metalsmith-flatten plugin to plugins.json

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -150,6 +150,12 @@
     "description": "Insert a hash of the content into the file name."
   },
   {
+    "name": "Flatten",
+    "icon": "files",
+    "repository": "https://github.com/chadly/metalsmith-flatten",
+    "description": "Flatten a directory hierarchy."
+  },
+  {
     "name": "Gist",
     "icon": "fork",
     "repository": "https://github.com/expalmer/metalsmith-gist",


### PR DESCRIPTION
A [metalsmith plugin](https://github.com/chadly/metalsmith-flatten) to flatten a directory hierarchy.