### PR TITLE
Add Browser Sync plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -24,6 +24,12 @@
     "description": "Run separate metalsmith pipelines on selected files."
   },
   {
+    "name": "Browser Sync",
+    "icon": "steampot",
+    "repository": "https://github.com/mdvorscak/metalsmith-browser-sync",
+    "description": "Leverage Browser Sync for an easier development workflow."
+  },
+  {
     "name": "Build Date",
     "icon": "clock",
     "repository": "https://github.com/segmentio/metalsmith-build-date",


### PR DESCRIPTION
Wanted to be able to easily integrate [BrowserSync] (http://www.browsersync.io/) into my projects. I tried [watch](https://github.com/FWeinb/metalsmith-watch), but it was a little dated (they're still using live-reload) so I decided to create a plugin for BrowserSync instead.