### PR TITLE
Add Broken Link Checker plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -24,6 +24,12 @@
     "description": "Run separate metalsmith pipelines on selected files."
   },
   {
+    "name": "Broken Link Checker",
+    "icon": "link",
+    "repository": "https://github.com/davidxmoody/metalsmith-broken-link-checker",
+    "description": "Check for relative and root-relative broken links."
+  },
+  {
     "name": "Browser Sync",
     "icon": "steampot",
     "repository": "https://github.com/mdvorscak/metalsmith-browser-sync",


### PR DESCRIPTION
Hi, 

I'm a big fan of Metalsmith, I've been using it to build my blog for a while and I've also recently started using it for a new static site at work. 

There have been a few times when I've accidentally made a typo and broken an internal link which gave me inspiration for this plugin. 

It's also the first time I've ever published anything to npm or submitted a pull request so feedback of any kind is very welcome :D

Anyway, this pull request is just to add it to the list of plugins on metalsmith.io.

All the best,
David