### PR TITLE
Add JSTransformer suite of Plugins

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -307,6 +307,24 @@
     "description": "Parse .json files and make their properties available to downstream plugins."
   },
   {
+    "name": "JSTransformer",
+    "icon": "files",
+    "repository": "https://github.com/RobLoach/metalsmith-jstransformer",
+    "description": "Compile content with any JSTransformer."
+  },
+  {
+    "name": "JSTransformer Layouts",
+    "icon": "gridlines",
+    "repository": "https://github.com/RobLoach/metalsmith-jstransformer-layouts",
+    "description": "Apply layouts to your source files through any JSTransformer."
+  },
+  {
+    "name": "JSTransformer Partials",
+    "icon": "file",
+    "repository": "https://github.com/RobLoach/metalsmith-jstransformer-partials",
+    "description": "Provide `partial` helpers with any JSTransformer."
+  },
+  {
     "name": "KSS",
     "icon": "files",
     "repository": "https://github.com/kwizzn/metalsmith-kss",


### PR DESCRIPTION
[JSTransformers](http://github.com/jstransformers) are the next iteration of [transformers](http://npm.im/transformers). Similar to consolidate.js, but with a different design and API. This PR adds three different plugins that use JSTransformers:

* [Metalsmith JSTransformer](https://github.com/RobLoach/metalsmith-jstransformer)
* [Metalsmith JSTransformer Layouts](https://github.com/RobLoach/metalsmith-jstransformer-layouts)
* [Metalsmith JSTransformer Partials](https://github.com/RobLoach/metalsmith-jstransformer-partials)