### PR TITLE
Add Unlisted plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -764,6 +764,12 @@
     "description": "Remove unused CSS rules with UnCSS"
   },
   {
+    "name": "Unlisted",
+    "icon": "files",
+    "repository": "https://github.com/alisdair/metalsmith-unlisted",
+    "description": "Remove pages from collections, but still allow them to build"
+  },
+  {
     "name": "Validate",
     "icon": "files",
     "repository": "https://github.com/mikestopcontinues/metalsmith-validate",


### PR DESCRIPTION
Remove pages from collections, but still allow them to build. Useful for writing draft weblog posts and sharing with people, while not updating your listings or RSS feed.

https://github.com/alisdair/metalsmith-unlisted