### PR TITLE
add metalsmith-rootpath to plugin list

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -548,6 +548,12 @@
     "description": "Grab content from the web and expose the results to metadata."
   },
   {
+    "name": "Root Path",
+    "icon": "link",
+    "repository": "https://github.com/radiovisual/metalsmith-rootpath",
+    "description": "Auto-calculate the relative path to your root directory in template urls."
+  },
+  {
     "name": "S3",
     "icon": "files",
     "repository": "https://github.com/mwishek/metalsmith-s3",


### PR DESCRIPTION
I found the functionality to auto-calculate the relative path back to the root directory extremely useful in my latest Metalsmith project, so I created the plugin [metalsmith-rootpath](https://github.com/radiovisual/metalsmith-rootpath). I used this plugin to easily create a relative navigation system, and auto-calculate the relative location of my static files. It has served me well, so perhaps someone else can find some value in it. 
 

 