### PR TITLE
Add fingerprint-ignore plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -193,6 +193,12 @@
     "description": "Insert a hash of the content into the file name."
   },
   {
+    "name": "Fingerprint Ignore",
+    "icon": "files",
+    "repository": "https://github.com/superwolff/metalsmith-fingerprint-ignore",
+    "description": "Insert a hash of the content into the file name and discard the original file."
+  },
+  {
     "name": "Flatten",
     "icon": "files",
     "repository": "https://github.com/chadly/metalsmith-flatten",


### PR DESCRIPTION
Metalsmith fingerprint does not discard the original file after fingerprinting. So when fingerprinting a large collection of files you'll have to manually ignore them all. Unfortunately the only predictable difference between the original and the fingerprinted file is the dash before the fingerprint (which limits your naming possibilities).

An issue was opened to address this, but closed as wontfix. So this fork is based on the PR by callum, which can be used by those who would still like this functionality.
