### PR TITLE
Add mapsite plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -379,6 +379,12 @@
     "description": "Implement Lunr.js client-side search engine."
   },
   {
+    "name": "Mapsite",
+    "icon": "addfile",
+    "repository": "https://github.com/superwolff/metalsmith-mapsite",
+    "description": "Generate a sitemap.xml file with sitemap.js."
+  },
+  {
     "name": "Markdown",
     "icon": "compose",
     "repository": "https://github.com/segmentio/metalsmith-markdown",


### PR DESCRIPTION
Add mapsite plugin, for generating a sitemap.xml file (with the [sitemap.js](https://github.com/ekalinin/sitemap.js) library). Will add any .html files in the pipeline by default.