### PR TITLE
Added skeleton gallery plugin to list of plugins

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -650,6 +650,12 @@
     "description": "Render wordpress-esque shortcodes via templates."
   },
   {
+    "name": "Skeleton Gallery",
+    "icon": "image",
+    "repository": "https://github.com/petermorlion/metalsmith-skeleton-gallery",
+    "description": "Generate an image gallery, using the Skeleton CSS framework."
+  },
+  {
     "name": "Slug",
     "icon": "hyphen",
     "repository": "https://github.com/nsonnad/metalsmith-slug",


### PR DESCRIPTION
I've created a small plugin to generate a simple gallery of images, using the Skeleton CSS framework. It doesn't do very much, and there is already a general gallery plugin, so I'm not sure if you want to list it on the Metalsmith homepage. But if you do, here's the pull request.