### PR TITLE
Adding metalsmith-discover-partials & metalsmith-discover-helpers

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -139,6 +139,18 @@
      "description": "Manually define values in the metadata."
   },
   {
+    "name": "Discover Helpers",
+    "icon": "file",
+    "repository": "https://github.com/timdp/metalsmith-discover-helpers",
+    "description": "Discovers your template helpers and registers them with Handlebars."
+  },
+  {
+    "name": "Discover Partials",
+    "icon": "file",
+    "repository": "https://github.com/timdp/metalsmith-discover-partials",
+    "description": "Discovers your template partials and registers them with Handlebars."
+  },
+  {
     "name": "Drafts",
     "icon": "erase",
     "repository": "https://github.com/segmentio/metalsmith-drafts",


### PR DESCRIPTION
`metalsmith-register-partials` is broken and unmaintained, so I wrote my own version. Since the logic for helpers is similar, I built that as well.