### PR TITLE
Update plugins.json

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -235,6 +235,12 @@
     "description": "Flatten a directory hierarchy."
   },
   {
+    "name": "Project images",
+    "icon": "image",
+    "repository": "https://github.com/hoetmaaiers/metalsmith-project-images",
+    "description": "Scan images in specified subfolder and add it to metadata."
+  },
+  {
     "name": "Gallery",
     "icon": "image",
     "repository": "https://github.com/clemsos/metalsmith-scan-images",


### PR DESCRIPTION
Add project-images plugin. 

This plugin is quite similar to what https://github.com/clemsos/metalsmith-scan-images tries to do. Yet the scan-images seems not to work neither be maintained.