### PR TITLE
Add metalsmith-matters to plugin list

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -469,6 +469,12 @@
     "description": "Highlight code in markdown files with highlight.js."
   },
   {
+    "name": "Metalsmith Matters",
+    "icon": "file",
+    "repository": "https://github.com/Ajedi32/metalsmith-matters",
+    "description": "Read file metadata from frontmatter."
+  },
+  {
     "name": "More",
     "icon": "crop",
     "repository": "https://github.com/kfranqueiro/metalsmith-more",


### PR DESCRIPTION
Note that I choose to keep the name "Metalsmith" in the plugin's name here (unlike the other plugins in the list) in order to preserve the cheeky pun. :wink:

Fixes ajedi32/metalsmith-matters#5